### PR TITLE
only selects SYSTEM tokens without Process Protection

### DIFF
--- a/SharpImpersonation/Resources/Constants.cs
+++ b/SharpImpersonation/Resources/Constants.cs
@@ -510,6 +510,11 @@ namespace SharpImpersonation
         public _LUID ModifiedId;
     }
 
+    [StructLayout(LayoutKind.Sequential)]
+    public struct _PROCESS_PROTECTION_LEVEL_INFORMATION
+    {
+        public DWORD ProtectionLevel;
+    }
 
     [StructLayout(LayoutKind.Sequential)]
     public struct _PRIVILEGE_SET
@@ -564,6 +569,22 @@ namespace SharpImpersonation
         TokenSecurityAttributes,
         TokenIsRestricted,
         MaxTokenInfoClass
+    }
+
+    [Flags]
+    public enum _PROCESS_INFORMATION_CLASS
+    {
+        ProcessMemoryPriority,
+        ProcessMemoryExhaustionInfo,
+        ProcessAppMemoryInfo,
+        ProcessInPrivateInfo,
+        ProcessPowerThrottling,
+        ProcessReservedValue1,
+        ProcessTelemetryCoverageInfo,
+        ProcessProtectionLevelInfo,
+        ProcessLeapSecondInfo,
+        ProcessMachineTypeInfo,
+        ProcessInformationClassMax
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/SharpImpersonation/Unmanaged.cs
+++ b/SharpImpersonation/Unmanaged.cs
@@ -5,6 +5,8 @@ using System.Text;
 
 namespace SharpImpersonation
 {
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    delegate Boolean GetProcessInformation(IntPtr hProcess, _PROCESS_INFORMATION_CLASS processInformationClass, ref _PROCESS_PROTECTION_LEVEL_INFORMATION processInformation, uint processInformationSize);
 
     [UnmanagedFunctionPointer(CallingConvention.StdCall)]
     delegate Boolean OpenProcessToken(IntPtr hProcess, UInt32 dwDesiredAccess, out IntPtr hToken);


### PR DESCRIPTION
Iterates through the first SYSTEM token and if the currently iterated token has NO Process Protection (0xFFFFFFFE), then it adds it to the "users" dictionary. Likewise, if the process is protected, that token is ignored and the loop continues until an unprotected process is found.

This prevents the occurrence of "GetPrimaryToken failed!" errors caused by Process Protections (which occurred quite frequently during our teams usage).

Use Cases Tested:
- SharpImpersonation.exe list
- SharpImpersonation.exe binary:cmd.exe user:"NT AUTHORITY\SYSTEM"

To replicate the error message that my team saw, just flip the "==" on line 286 of Enum.cs to "!=" and the program will attempt to use the token of a protected process.